### PR TITLE
add raw string prefix to re.match

### DIFF
--- a/rt-trace-bcc.py
+++ b/rt-trace-bcc.py
@@ -80,7 +80,7 @@ cur_pid = os.getpid()
 tracing_started = True
 
 # Detect RHEL8
-if re.match(".*\.el8\..*", platform.release()):
+if re.match(r".*\.el8\..*", platform.release()):
     os_version = "rhel8"
 else:
     os_version = "upstream"


### PR DESCRIPTION
fix warning
rt-trace-bcc.py:83: SyntaxWarning: invalid escape sequence '\.'